### PR TITLE
src: extension: show the correct 'ramalama run' command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -176,7 +176,7 @@ async function showRamalamaRun() {
 	title: "ramalama run",
 	prompt: "RamaLama command to launch a model",
 	multiline: true,
-	value: `ramalama --image "${RamalamaRemotingImage}" run llama3.2`,
+	value: `ramalama run --image "${RamalamaRemotingImage}" llama3.2`,
     });
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the RamaLama run command shown in the input dialog to use the proper format: “ramalama run --image …”. Replaces the outdated “ramalama --image … run … llama3.2” string, improving accuracy for users copying or executing the suggested command. No other functional behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->